### PR TITLE
Bumps latest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ crash.log
 credentials.json
 
 test/fixtures/*/ssh/key
+examples/simple_example/.terraform.lock.hcl

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -16,7 +16,7 @@
 
 provider "google" {
   region  = var.region
-  version = "~> 2.12.0"
+  version = "~> 3.79.0"
 }
 
 locals {

--- a/examples/simple_example/versions.tf
+++ b/examples/simple_example/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 1.0.4"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,8 @@ variable "jenkins_instance_machine_type" {
 
 variable "jenkins_boot_disk_source_image" {
   description = "The name of the disk image to use as the boot disk for the Jenkins master"
-  default = "bitnami-jenkins-2-222-4-3-r01-linux-debian-10-x86-64-nami"
+	# gcloud compute images list --project bitnami-launchpad --filter="name:jenkins" --uri
+  default = "bitnami-jenkins-2-289-3-0-linux-debian-10-x86-64-nami"
 }
 
 variable "jenkins_boot_disk_source_image_project" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,9 +15,12 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 1.0.4"
 
   required_providers {
-    google = "~> 2.12"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.79.0"
+    }
   }
 }


### PR DESCRIPTION
google provider ~> 3.79.0
terraform ~> 1.0.4
jenkins_boot_disk_source_image = bitnami-jenkins-2-289-3-0-linux-debian-10-x86-64-nami